### PR TITLE
Switch to alpine

### DIFF
--- a/Source/Dockerfile
+++ b/Source/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/sdk:5.0 AS build-env
+FROM mcr.microsoft.com/dotnet/sdk:5.0-alpine3.13 AS build-env
 WORKDIR /app
 
 VOLUME [ "/app/data" ]
@@ -7,16 +7,17 @@ COPY Source/ ./Source/
 
 WORKDIR /app/Source
 
-RUN dotnet restore
+RUN dotnet restore --runtime alpine-x64
 
-RUN dotnet publish -c Release -o out
+RUN dotnet publish -c Release -o out --no-restore 
 
-FROM mcr.microsoft.com/dotnet/runtime:5.0-buster-slim
+FROM mcr.microsoft.com/dotnet/runtime:5.0-alpine3.13
 WORKDIR /app
 COPY --from=build-env /app/Source/out ./
 COPY --from=build-env /app/Source/data ./data
 
-RUN useradd -ms /bin/bash moduleuser
+RUN adduser -Ds /bin/sh moduleuser	
+
 USER moduleuser
 
 EXPOSE 5100/udp


### PR DESCRIPTION
## Summary

Move from buster to alpine image. Reduce size from 192MB to 89MB. Also reducing vulnerabilities

### Changed

- Dockerfile: Changed from buster to alpine

### Security

- Removes security vulnerabilities from docker scan
