### PR TITLE
Remove sonar token for security

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -4,7 +4,6 @@ env:
   PRERELEASE_BRANCHES: experimental,alpha,beta,rc # Comma separated list of prerelease branch names. 'alpha,rc, ...'
   DOCKER_HUB_REPO: ${{ secrets.RAAEDGE_LOGIN_SERVER }}/connectors-nmea #  The docker hub repo to push to
   COVERAGE_FOLDER: Coverage
-  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:


### PR DESCRIPTION
## Summary

Remove sonar token from dotnet action to reduce security risk.

### Removed

- sonar token from dotnet action (not required in the dotnet action)