### PR TITLE
Trying to push latest tag

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -67,8 +67,8 @@ jobs:
     - name: Docker push
       if: ${{ steps.context.outputs.should-publish == 'true' && env.DOCKER_HUB_REPO != '' }}
       run: |
-          docker build --no-cache -f $GITHUB_WORKSPACE/Source/Dockerfile -t ${{ env.DOCKER_HUB_REPO }}:${{ steps.increment-version.outputs.next-version }} .
-          docker push ${{ env.DOCKER_HUB_REPO }}:${{ steps.increment-version.outputs.next-version }}
+          docker build --no-cache -f $GITHUB_WORKSPACE/Source/Dockerfile -t ${{ env.DOCKER_HUB_REPO }}:${{ steps.increment-version.outputs.next-version }} -t ${{ env.DOCKER_HUB_REPO }}:latest .
+          docker push ${{ env.DOCKER_HUB_REPO }} --all-tags
         
     - name: Create GitHub Release
       uses: dolittle/github-release-action@v1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -68,7 +68,8 @@ jobs:
       if: ${{ steps.context.outputs.should-publish == 'true' && env.DOCKER_HUB_REPO != '' }}
       run: |
           docker build --no-cache -f $GITHUB_WORKSPACE/Source/Dockerfile -t ${{ env.DOCKER_HUB_REPO }}:${{ steps.increment-version.outputs.next-version }} -t ${{ env.DOCKER_HUB_REPO }}:latest .
-          docker push ${{ env.DOCKER_HUB_REPO }} --all-tags
+          docker push ${{ env.DOCKER_HUB_REPO }}:${{ steps.increment-version.outputs.next-version }}
+          docker push ${{ env.DOCKER_HUB_REPO }}:latest
         
     - name: Create GitHub Release
       uses: dolittle/github-release-action@v1

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -46,6 +46,7 @@ jobs:
         password: ${{ secrets.RAAEDGE_ACR_PASSWORD }}
 
     - name: Docker Build
+      if: ${{ steps.context.outputs.should-publish == 'false' }}
       shell: bash
       run: |
           docker build --no-cache -f $GITHUB_WORKSPACE/Source/Dockerfile -t ${{ env.DOCKER_HUB_REPO }}:${{ github.sha }} .

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,6 +45,11 @@ jobs:
         username: ${{ secrets.RAAEDGE_ACR_USERNAME }}
         password: ${{ secrets.RAAEDGE_ACR_PASSWORD }}
 
+    - name: Docker Build
+      shell: bash
+      run: |
+          docker build --no-cache -f $GITHUB_WORKSPACE/Source/Dockerfile -t ${{ env.DOCKER_HUB_REPO }}:${{ github.sha }} .
+
     - name: Establish context
       id: context
       uses: dolittle/establish-context-action@v2

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -45,11 +45,6 @@ jobs:
         username: ${{ secrets.RAAEDGE_ACR_USERNAME }}
         password: ${{ secrets.RAAEDGE_ACR_PASSWORD }}
 
-    - name: Docker Build
-      shell: bash
-      run: |
-          docker build --no-cache -f $GITHUB_WORKSPACE/Source/Dockerfile -t ${{ env.DOCKER_HUB_REPO }}:${{ github.sha }} .
-
     - name: Establish context
       id: context
       uses: dolittle/establish-context-action@v2


### PR DESCRIPTION
## Summary

Push latest tag. Labelling this PR with "patch" to get a test run of the github action.


### Changed

- Adapted github action to tag image with latest and push it to the acr each time a regular version is pushed.

### Removed

- Removed a docker build command that build & tagged image with the commit id. That tag has so far not been used.  I believe having a docker build when we push new image version is enough. Benefit is to speed up the build.