### PR TITLE
parsing the PV00CT from hex to double

### DIFF
--- a/Source/SentenceFormats/00CT.cs
+++ b/Source/SentenceFormats/00CT.cs
@@ -18,13 +18,25 @@ namespace RaaLabs.Edge.Connectors.NMEA.SentenceFormats
         public IEnumerable<TagWithData> Parse(string[] values)
         {
             var flowMainEngineIn = values[1];
-            var flowAuxEngineIn = values[2];
-            var flowBoilerIn = values[3];
+            var flowAuxEngineIn = values[3];
+            var flowBoilerIn = values[5];
 
+            if (parser.ValidSentenceValue(flowMainEngineIn))
+            {
+                var parsedFlowMainEngineIn = int.Parse(flowMainEngineIn, System.Globalization.NumberStyles.HexNumber);
+                yield return new TagWithData("FlowMainEngineIn",  (float) parsedFlowMainEngineIn);
+            } 
+            if (parser.ValidSentenceValue(flowAuxEngineIn)) 
+            {
+                var parsedFlowAuxEngineIn = int.Parse(flowAuxEngineIn, System.Globalization.NumberStyles.HexNumber);
+                yield return new TagWithData("FlowAuxEngineIn",  (float) parsedFlowAuxEngineIn);
+            }
 
-            if (parser.ValidSentenceValue(flowMainEngineIn)) yield return new TagWithData("FlowMainEngineIn",  parser.StringToDouble(flowMainEngineIn));
-            if (parser.ValidSentenceValue(flowAuxEngineIn)) yield return new TagWithData("FlowAuxEngineIn",  parser.StringToDouble(flowAuxEngineIn));
-            if (parser.ValidSentenceValue(flowBoilerIn)) yield return new TagWithData("FlowBoilerIn",  parser.StringToDouble(flowBoilerIn));
+            if (parser.ValidSentenceValue(flowBoilerIn))
+            {
+                var parsedFlowBoilerIn = int.Parse(flowBoilerIn, System.Globalization.NumberStyles.HexNumber);
+                yield return new TagWithData("FlowBoilerIn",  (float) parsedFlowBoilerIn);
+            } 
 
         }
       

--- a/Specifications/Features/ProprietaryNMEASentences.feature
+++ b/Specifications/Features/ProprietaryNMEASentences.feature
@@ -5,13 +5,13 @@ Feature: ProprietaryNMEASentences
 
     Scenario: Handling incoming _00CT events
         When the following events of type NMEASentenceReceived is produced
-            | sentence                     |
-            | $PV00CT,03,0.0,3500.0,2000.0 |
+            | sentence                                               |
+            | $PV00CT,1BC7DD3,1993F218,0,1062A793,0,3119015,0,0,0*01 |
         Then the following events of type EventParsed is produced
-            | Talker | Tag              | Value  |
-            | PV00CT | FlowMainEngineIn | 0.0    |
-            | PV00CT | FlowAuxEngineIn  | 3500.0 |
-            | PV00CT | FlowBoilerIn     | 2000.0 |
+            | Talker | Tag              | Value     |
+            | PV00CT | FlowMainEngineIn | 429126168 |
+            | PV00CT | FlowAuxEngineIn  | 274900883 |
+            | PV00CT | FlowBoilerIn     | 51482645  |
 
     Scenario: Handling incoming TEMPAI events
         When the following events of type NMEASentenceReceived is produced


### PR DESCRIPTION
## Summary

The PV00CT appears to send data as hexidecimal numbers, and are therefore now parsed