### PR TITLE
Polly now handles retries correctly.

### DIFF
--- a/Source/NMEALineHandler.cs
+++ b/Source/NMEALineHandler.cs
@@ -59,9 +59,9 @@ namespace RaaLabs.Edge.Connectors.NMEA
                     });
                 }
             }
-            catch (FormatException ex)
+            catch (Exception ex)
             {
-                _logger.Error(ex, $"Trouble parsing  {@event}");
+                _logger.Error(ex, "Trouble parsing {event}", @event);
             }
         }
     }


### PR DESCRIPTION
## Summary
This PR fixes the Polly retry logic, by wrapping a policy that has exponential backoff retry logic (and catches SocketException, which will be thrown during connection) inside a policy that restarts the inner handler immediately when an Exception is thrown.